### PR TITLE
Enable custom accessibilityLabel

### DIFF
--- a/Sources/AccessibleAuthorLabel/AccessibleAuthorLabel.swift
+++ b/Sources/AccessibleAuthorLabel/AccessibleAuthorLabel.swift
@@ -16,15 +16,17 @@ public class AccessibleLabel: UILabel {
         guard let mapping = NSDictionary(contentsOf: plistURL) as? [String: String] else { return [:] }
         return mapping
     }()
+    
+    private var _accessibilityLabel: String?
 
-    /// Automatically converts our text into something easier for VoiceOver to read.
+    /// If accessibilityLabel is not set, converts our text into something easier for VoiceOver to read.
     override public var accessibilityLabel: String? {
         get {
-            text?.map { Self.characterMapping[$0.lowercased()] ?? "" }.joined()
+            _accessibilityLabel ?? text?.map { Self.characterMapping[$0.lowercased()] ?? "" }.joined()
         }
 
         set {
-            super.accessibilityLabel = newValue
+            _accessibilityLabel = newValue
         }
     }
 }


### PR DESCRIPTION
Even though UILabel can be used if we want to set a custom accessibilityLabel, wouldn't it sometimes be useful to be able to it set it on AccessibleLabel too?

This addition uses the custom accessibilityLabel if set.